### PR TITLE
Minor: dropping deprecated functions for future support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prepare repository
         run: git fetch --unshallow --tags

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current version
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create files to sync
         run: |
           mkdir docs/
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current version
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create files to sync
         run: |
           mkdir docs/
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current version
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create files to sync
         run: |
           mkdir docs/
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current version
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
       - name: Create files to sync
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current version
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create files to sync
         run: |
           mkdir docs/

--- a/.github/workflows/verification_tests.yml
+++ b/.github/workflows/verification_tests.yml
@@ -32,7 +32,7 @@ jobs:
           mkdir -p tmp/
           out=$(mktemp tempfileXXXXXXXX --suffix=.action.tmp --tmpdir=./tmp/)
           out=$(basename "$out")
-          echo "::set-output name=tempfile::$out"
+          echo "tempfile=$out" >> $GITHUB_OUTPUT
         id: tempfile
       - name: Push with local action
         uses: ./

--- a/.github/workflows/verification_tests.yml
+++ b/.github/workflows/verification_tests.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.author_association == 'OWNER'
     steps:
       - name: Checkout current version
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create tmp file
         run: |
           mkdir -p tmp/

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ folder to the wiki of the current repository:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout current version
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
         - name: Create files to sync
           run: |
             mkdir docs/

--- a/entrypoint.fish
+++ b/entrypoint.fish
@@ -27,7 +27,7 @@ function set_output -a "name" "output"
     end
     # Should be single line otherwise would need to esape chars for output
     # Tried https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870
-    echo "::set-output name=$name""::$output"
+    echo "$name=$output" >> $GITHUB_OUTPUT
 end
 
 function mask -a "secret" -d "Git style of hiding output"


### PR DESCRIPTION
## Current Script Warnings:
> [!WARNING] 
> [Sync docs]
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

> [!WARNING] 
> [Sync docs]
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Fixes:
- checkout v3 instead of v2
- update `::set-output` to the latest version